### PR TITLE
Fix admin notice query arg encoding

### DIFF
--- a/virtual-product-pages.php
+++ b/virtual-product-pages.php
@@ -313,7 +313,7 @@ class VPP_Plugin {
         $key = isset($_POST['vpp_key']) ? sanitize_text_field(wp_unslash($_POST['vpp_key'])) : '';
         list($type, $val) = $this->parse_lookup_key($key);
         if (!$type) {
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('Enter a valid URL, slug or ID.')], admin_url('admin.php?page=vpp_edit'));
+            $redirect = add_query_arg(['vpp_err'=> 'Enter a valid URL, slug or ID.'], admin_url('admin.php?page=vpp_edit'));
         } else {
             $redirect = add_query_arg(['lookup_type'=> $type, 'lookup_val'=> $val], admin_url('admin.php?page=vpp_edit'));
         }
@@ -372,7 +372,7 @@ class VPP_Plugin {
         $table = preg_replace('/[^a-zA-Z0-9_]/', '', $s['tidb']['table']);
         $mysqli = $this->db_connect($err);
         if (!$mysqli) {
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('DB error: ' . $err)], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
+            $redirect = add_query_arg(['vpp_err'=> 'DB error: ' . $err], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
             wp_safe_redirect($redirect); exit;
         }
 
@@ -408,7 +408,7 @@ class VPP_Plugin {
 
         if (empty($set_parts)) {
             $mysqli->close();
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('No editable columns found in table.')], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
+            $redirect = add_query_arg(['vpp_err'=> 'No editable columns found in table.'], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
             wp_safe_redirect($redirect); exit;
         }
 
@@ -416,7 +416,7 @@ class VPP_Plugin {
         $stmt = $mysqli->prepare($sql);
         if (!$stmt) {
             $mysqli->close();
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('DB prepare failed: ' . $mysqli->error)], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
+            $redirect = add_query_arg(['vpp_err'=> 'DB prepare failed: ' . $mysqli->error], admin_url('admin.php?page=vpp_edit&lookup_type=id&lookup_val='.$id));
             wp_safe_redirect($redirect); exit;
         }
 
@@ -452,11 +452,11 @@ class VPP_Plugin {
             }
         }
 
-        $args = ['lookup_type'=>'id','lookup_val'=>$id,'vpp_msg'=>rawurlencode($top_msg),'inline'=>$inline,'inline_msg'=>rawurlencode($inline_msg)];
+        $args = ['lookup_type'=>'id','lookup_val'=>$id,'vpp_msg'=>$top_msg,'inline'=>$inline,'inline_msg'=>$inline_msg];
         $redirect = add_query_arg($args, admin_url('admin.php?page=vpp_edit'));
 
         if (isset($_POST['do_save_view']) && $ok) {
-            $redirect = add_query_arg(['vpp_msg'=> rawurlencode($top_msg . ' Open: ' . home_url('/p/' . $slug))] + $args, admin_url('admin.php?page=vpp_edit'));
+            $redirect = add_query_arg(['vpp_msg'=> $top_msg . ' Open: ' . home_url('/p/' . $slug)] + $args, admin_url('admin.php?page=vpp_edit'));
         }
 
         wp_safe_redirect($redirect); exit;
@@ -470,7 +470,7 @@ class VPP_Plugin {
         $input = isset($_POST[self::OPT_KEY]) ? (array) $_POST[self::OPT_KEY] : [];
         $clean = $this->sanitize_settings($input);
         update_option(self::OPT_KEY, $clean, false); // persistent
-        $redirect = add_query_arg(['vpp_msg'=> rawurlencode('Settings saved.')], admin_url('admin.php?page=vpp_settings'));
+        $redirect = add_query_arg(['vpp_msg'=> 'Settings saved.'], admin_url('admin.php?page=vpp_settings'));
         wp_safe_redirect($redirect); exit;
     }
 
@@ -480,7 +480,7 @@ class VPP_Plugin {
         $err = null;
         $conn = $this->db_connect($err);
         if ($conn) { @$conn->close(); $ok = true; } else { $ok = false; }
-        $redirect = add_query_arg([$ok ? 'vpp_msg' : 'vpp_err' => rawurlencode($ok ? 'TiDB connection OK.' : ('TiDB connection failed: ' . $err))], admin_url('admin.php?page=vpp_settings'));
+        $redirect = add_query_arg([$ok ? 'vpp_msg' : 'vpp_err' => $ok ? 'TiDB connection OK.' : ('TiDB connection failed: ' . $err)], admin_url('admin.php?page=vpp_settings'));
         wp_safe_redirect($redirect); exit;
     }
 
@@ -492,7 +492,7 @@ class VPP_Plugin {
         $key = trim($s['algolia']['admin_key'] ?? '');
         $index = trim($s['algolia']['index'] ?? '');
         if (!$app || !$key || !$index) {
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('Algolia not configured (app_id, admin_key, index required).')], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_err'=> 'Algolia not configured (app_id, admin_key, index required).'], admin_url('admin.php?page=vpp_settings'));
             wp_safe_redirect($redirect); exit;
         }
         $endpoint = "https://{$app}-dsn.algolia.net/1/indexes/" . rawurlencode($index);
@@ -505,13 +505,13 @@ class VPP_Plugin {
             'timeout' => 10,
         ]);
         if (is_wp_error($resp)) {
-            $redirect = add_query_arg(['vpp_err'=> rawurlencode('Algolia request failed: ' . $resp->get_error_message())], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_err'=> 'Algolia request failed: ' . $resp->get_error_message()], admin_url('admin.php?page=vpp_settings'));
         } else {
             $code = wp_remote_retrieve_response_code($resp);
             if ($code >= 200 && $code < 300) {
-                $redirect = add_query_arg(['vpp_msg'=> rawurlencode('Algolia connection OK.')], admin_url('admin.php?page=vpp_settings'));
+                $redirect = add_query_arg(['vpp_msg'=> 'Algolia connection OK.'], admin_url('admin.php?page=vpp_settings'));
             } else {
-                $redirect = add_query_arg(['vpp_err'=> rawurlencode('Algolia HTTP ' . $code)], admin_url('admin.php?page=vpp_settings'));
+                $redirect = add_query_arg(['vpp_err'=> 'Algolia HTTP ' . $code], admin_url('admin.php?page=vpp_settings'));
             }
         }
         wp_safe_redirect($redirect); exit;
@@ -884,7 +884,10 @@ class VPP_Plugin {
                 $ok++;
             } else { $fail++; $msg = $err ?: 'Unknown error'; }
         }
-        $redirect = add_query_arg($fail ? ['vpp_err'=> rawurlencode("Published {$ok}, failed {$fail}. {$msg}")] : ['vpp_msg'=> rawurlencode("Published {$ok}, failed {$fail}.")], admin_url('admin.php?page=vpp_settings'));
+        $params = $fail
+            ? ['vpp_err'=> "Published {$ok}, failed {$fail}. {$msg}"]
+            : ['vpp_msg'=> "Published {$ok}, failed {$fail}."];
+        $redirect = add_query_arg($params, admin_url('admin.php?page=vpp_settings'));
         wp_safe_redirect($redirect); exit;
     }
 
@@ -900,7 +903,10 @@ class VPP_Plugin {
             if ($product && $this->push_algolia($product, $err)) { $ok++; }
             else { $fail++; $msg = $err ?: 'Unknown error'; }
         }
-        $redirect = add_query_arg($fail ? ['vpp_err'=> rawurlencode("Algolia push: {$ok} ok, {$fail} failed. {$msg}")] : ['vpp_msg'=> rawurlencode("Algolia push: {$ok} ok, {$fail} failed.")], admin_url('admin.php?page=vpp_settings'));
+        $params = $fail
+            ? ['vpp_err'=> "Algolia push: {$ok} ok, {$fail} failed. {$msg}"]
+            : ['vpp_msg'=> "Algolia push: {$ok} ok, {$fail} failed."];
+        $redirect = add_query_arg($params, admin_url('admin.php?page=vpp_settings'));
         wp_safe_redirect($redirect); exit;
     }
 
@@ -910,9 +916,9 @@ class VPP_Plugin {
         $err = null;
         $ok = $this->purge_cloudflare([], $err);
         if ($ok) {
-            $redirect = add_query_arg(['vpp_msg' => rawurlencode('Cloudflare cache purged.')], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_msg' => 'Cloudflare cache purged.'], admin_url('admin.php?page=vpp_settings'));
         } else {
-            $redirect = add_query_arg(['vpp_err' => rawurlencode($err ?: 'Cloudflare purge failed.')], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_err' => $err ?: 'Cloudflare purge failed.'], admin_url('admin.php?page=vpp_settings'));
         }
         wp_safe_redirect($redirect); exit;
     }
@@ -924,9 +930,9 @@ class VPP_Plugin {
         $err = null;
         $ok = $this->rebuild_sitemaps($summary, $err);
         if ($ok) {
-            $redirect = add_query_arg(['vpp_msg' => rawurlencode($summary ?: 'Sitemap rebuilt.')], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_msg' => $summary ?: 'Sitemap rebuilt.'], admin_url('admin.php?page=vpp_settings'));
         } else {
-            $redirect = add_query_arg(['vpp_err' => rawurlencode($err ?: 'Sitemap rebuild failed.')], admin_url('admin.php?page=vpp_settings'));
+            $redirect = add_query_arg(['vpp_err' => $err ?: 'Sitemap rebuild failed.'], admin_url('admin.php?page=vpp_settings'));
         }
         wp_safe_redirect($redirect); exit;
     }


### PR DESCRIPTION
## Summary
- remove rawurlencode wrapping from admin notice messages before passing to add_query_arg
- allow WordPress to handle encoding so admin notices display human-readable text
- refactor push handlers to reuse add_query_arg without manual encoding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe35ca39883238c1f035bd9fd2e40